### PR TITLE
feat: Add course_tabs endpoint support

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -26,6 +26,7 @@ use Eduframe\Resources\SignupQuestion;
 use Eduframe\Resources\Teacher;
 use Eduframe\Resources\CatalogProduct;
 use Eduframe\Resources\CatalogVariant;
+use Eduframe\Resources\CourseTab;
 
 class Client
 {
@@ -130,6 +131,10 @@ class Client
 
     public function catalog_variants(array $attributes = []): CatalogVariant {
         return new CatalogVariant($this->connection, $attributes);
+    }
+
+    public function course_tabs(array $attributes = []): CourseTab {
+        return new CourseTab($this->connection, $attributes);
     }
 
     public function getConnection(): Connection {

--- a/src/Resources/CourseTab.php
+++ b/src/Resources/CourseTab.php
@@ -3,11 +3,15 @@
 namespace Eduframe\Resources;
 
 use Eduframe\Resource;
+use Eduframe\Traits\FindAll;
+use Eduframe\Traits\FindOne;
 
 class CourseTab extends Resource
 {
+    use FindAll, FindOne;
 
     protected array $fillable = [
+        'id',
         'name',
         'position'
     ];


### PR DESCRIPTION
Register a course_tabs() method on the Client and make the CourseTab resource fetchable by adding the FindAll/FindOne traits. Also add 'id' to the fillable attributes so the resource id survives hydration (the base Resource drops non-fillable keys), which consumers need to map the tab to a local identifier.