### PR TITLE
fix: Expose id and course_tab_id on CourseTabContent

### DIFF
--- a/src/Resources/CourseTabContent.php
+++ b/src/Resources/CourseTabContent.php
@@ -8,6 +8,8 @@ class CourseTabContent extends Resource
 {
 
     protected array $fillable = [
+        'id',
+        'course_tab_id',
         'content',
         'course_tab'
     ];


### PR DESCRIPTION
## Problem

Version 2.1.0 hydrates `course_tab_contents` entries without their `id` and `course_tab_id` attributes: both are missing from `CourseTabContent::$fillable`, so `Resource` hydration strips them (2.0.0 still exposed both).

Consumers that upsert tab contents by external id — such as the Drupal `eduframe` module — silently receive unidentifiable entries and cannot link them to their course tab.

## Fix

Add `id` and `course_tab_id` back to the fillable list.

Ideally released as **2.1.1** so `drupal/eduframe` can constrain to `^2.1.1`.